### PR TITLE
Add basic GoogleTest setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ FetchContent_MakeAvailable(gtest)
 
 add_executable(bitvector main.cpp)
 
+# Unit tests
+add_executable(bitvector_tests bitvector_test.cpp)
+target_link_libraries(bitvector_tests GTest::gtest_main)
+
 
 # Link your project with Google Test (only for test purposes)
 #add_executable(PrimeIteratorTests test_prime_iterator.cpp)
@@ -63,5 +67,5 @@ add_executable(bitvector main.cpp)
 
 # Enable test discovery
 include(GoogleTest)
-#gtest_discover_tests(PrimeIteratorTests)
+gtest_discover_tests(bitvector_tests)
 

--- a/bitvector.hpp
+++ b/bitvector.hpp
@@ -345,7 +345,7 @@ namespace bowen
                 
                 BitType *new_data = m_allocator.allocate(new_word_count);
                 std::copy(m_data, m_data + m_capacity, new_data);
-                deallocate_memory(m_data);
+                deallocate_memory();
                 m_data = new_data;
                 m_capacity = new_word_count;
             }

--- a/bitvector_test.cpp
+++ b/bitvector_test.cpp
@@ -1,0 +1,30 @@
+#include "bitvector.hpp"
+#include <gtest/gtest.h>
+
+TEST(BitvectorTest, PushBackBasic) {
+    bowen::bitvector<> bv;
+    EXPECT_TRUE(bv.empty());
+
+    bv.push_back(false);
+    bv.push_back(true);
+    bv.push_back(true);
+
+    ASSERT_EQ(bv.size(), 3u);
+    EXPECT_FALSE(bv[0]);
+    EXPECT_TRUE(bv[1]);
+    EXPECT_TRUE(bv[2]);
+}
+
+TEST(BitvectorTest, IncrementUntilZero) {
+    const size_t N = 20;
+    bowen::bitvector<> bv(N);
+
+    // Set bits 5 through 7 to 1
+    for (size_t i = 5; i <= 7; ++i) {
+        bv.set_bit(i, true);
+    }
+
+    size_t pos = 5;
+    bv.incrementUntilZero(pos);
+    EXPECT_EQ(pos, 8u);
+}


### PR DESCRIPTION
## Summary
- add GoogleTest-based test file covering `push_back` and `incrementUntilZero`
- fix `reserve` to call `deallocate_memory()`
- build and run tests with `gtest_discover_tests`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_683fce7db7348327805ee3ae5c9ba200