### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: C++ CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build with CMake and run Google tests

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684220cd9c5483278336c3c0d699b3a3