### PR TITLE
Fix CI tests failing due to AVX512 usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,16 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Zi /DEBUG")
 endif()
 
-# Enable AVX-512 support
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(-mavx512f)
-elseif(MSVC)
-    message(WARNING "AVX-512 support is not available for MSVC in this configuration.")
+# Optionally enable AVX-512 instructions.  Most CI runners do not support
+# AVX-512, so leave it disabled by default to avoid illegal instruction
+# failures at runtime.
+option(ENABLE_AVX512 "Enable AVX-512 instructions" OFF)
+if(ENABLE_AVX512)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        add_compile_options(-mavx512f)
+    elseif(MSVC)
+        message(WARNING "AVX-512 support is not available for MSVC in this configuration.")
+    endif()
 endif()
 
 # Enable BMI1 support

--- a/bitvector.hpp
+++ b/bitvector.hpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <memory>
 #include <nmmintrin.h>
+#include <immintrin.h>
 #include <sstream>
 #include <stdexcept>
 #include <simde/x86/avx2.h>


### PR DESCRIPTION
## Summary
- make AVX512 compile flag optional
- include proper intrinsic header for tzcnt

## Testing
- `cmake -B build -S . -GNinja`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684223e0909c8327b10f0b783d426fb8