### PR TITLE
Add Google Benchmark for bitvector performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,5 @@ jobs:
         run: cmake --build build --config Release
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
+      - name: Run benchmarks
+        run: ./build/bitvector_benchmark --benchmark_min_time=0.01s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,15 @@ FetchContent_MakeAvailable(simde)
 include_directories(${simde_SOURCE_DIR})
 add_compile_definitions(SIMDE_ENABLE_NATIVE_ALIASES)
 
+# Google Benchmark
+FetchContent_Declare(
+    benchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.8.3
+)
+set(BENCHMARK_ENABLE_TESTING OFF)
+FetchContent_MakeAvailable(benchmark)
+
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 # Download and build Google Test
@@ -59,6 +68,10 @@ add_executable(bitvector main.cpp)
 # Unit tests
 add_executable(bitvector_tests bitvector_test.cpp)
 target_link_libraries(bitvector_tests GTest::gtest_main)
+
+# Benchmark target
+add_executable(bitvector_benchmark bitvector_benchmark.cpp)
+target_link_libraries(bitvector_benchmark benchmark::benchmark)
 
 
 # Link your project with Google Test (only for test purposes)

--- a/bitvector_benchmark.cpp
+++ b/bitvector_benchmark.cpp
@@ -1,0 +1,82 @@
+#include "bitvector.hpp"
+#include <benchmark/benchmark.h>
+#include <vector>
+
+using bowen::bitvector;
+
+static void BM_Bowen_Set(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    bitvector<> bv(n);
+    for (size_t i=0;i<n;++i) {
+      bv[i] = static_cast<bool>(i & 1);
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Std_Set(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    std::vector<bool> bv(n);
+    for (size_t i=0;i<n;++i) {
+      bv[i] = static_cast<bool>(i & 1);
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Bowen_PushBack(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    bitvector<> bv;
+    bv.reserve(n);
+    for (size_t i=0;i<n;++i) {
+      bv.push_back(static_cast<bool>(i & 1));
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Std_PushBack(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    std::vector<bool> bv;
+    bv.reserve(n);
+    for (size_t i=0;i<n;++i) {
+      bv.push_back(static_cast<bool>(i & 1));
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Bowen_Access(benchmark::State& state) {
+  size_t n = state.range(0);
+  bitvector<> bv(n);
+  for (size_t i=0;i<n;++i) bv[i] = static_cast<bool>(i & 1);
+  for (auto _ : state) {
+    size_t sum=0;
+    for (size_t i=0;i<n;++i) sum += bv[i];
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+static void BM_Std_Access(benchmark::State& state) {
+  size_t n = state.range(0);
+  std::vector<bool> bv(n);
+  for (size_t i=0;i<n;++i) bv[i] = static_cast<bool>(i & 1);
+  for (auto _ : state) {
+    size_t sum=0;
+    for (size_t i=0;i<n;++i) sum += bv[i];
+    benchmark::DoNotOptimize(sum);
+  }
+}
+
+BENCHMARK(BM_Bowen_Set)->Arg(1<<20);
+BENCHMARK(BM_Std_Set)->Arg(1<<20);
+BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20);
+BENCHMARK(BM_Std_PushBack)->Arg(1<<20);
+BENCHMARK(BM_Bowen_Access)->Arg(1<<20);
+BENCHMARK(BM_Std_Access)->Arg(1<<20);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
## Summary
- integrate Google Benchmark via FetchContent
- add benchmark target to CMake
- create `bitvector_benchmark.cpp` with performance tests comparing `bowen::bitvector` to `std::vector<bool>`
- run benchmark executable in GitHub Actions

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure`
- `./build/bitvector_benchmark --benchmark_min_time=0.01s`


------
https://chatgpt.com/codex/tasks/task_e_68438fba26b88327b99e6124ebc68a93