### PR TITLE
Add optional bounds checking toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 project(bitvector)
 
 set(CMAKE_CXX_STANDARD 17)
-option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" ON)
+option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" OFF)
 if(NOT BV_BOUNDS_CHECK)
   add_compile_definitions(BITVECTOR_DISABLE_BOUNDS_CHECK)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.21)
 project(bitvector)
 
 set(CMAKE_CXX_STANDARD 17)
+option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" ON)
+if(NOT BV_BOUNDS_CHECK)
+  add_compile_definitions(BITVECTOR_DISABLE_BOUNDS_CHECK)
+endif()
 if(MSVC)
   # Set compiler flags for all configurations
   #add_compile_options("/O2" "/Zi" "/DEBUG")

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# bitvector
+
+This repository provides a small bit vector implementation along with tests and benchmarks.
+
+## Running the benchmarks without bounds checking
+
+Bounds checking is enabled by default. To benchmark without checks, configure and build with:
+
+```bash
+cmake -S . -B build -DBV_BOUNDS_CHECK=OFF -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release
+./build/bitvector_benchmark
+```

--- a/bitvector.hpp
+++ b/bitvector.hpp
@@ -208,11 +208,13 @@ namespace bowen
 
         reference operator[](size_t pos)
         {
+#ifndef BITVECTOR_DISABLE_BOUNDS_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
+#endif
 
             size_t word_index = pos >> WORD_SHIFT;
             BitType mask = static_cast<BitType>(1) << (pos & (WORD_BITS - 1));
@@ -221,21 +223,25 @@ namespace bowen
 
         bool operator[](size_t pos) const
         {
+#ifndef BITVECTOR_DISABLE_BOUNDS_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
+#endif
             size_t word_index = pos >> WORD_SHIFT;
             BitType mask = static_cast<BitType>(1) << (pos & (WORD_BITS - 1));
             return (m_data[word_index] & mask) != 0;
         }
         inline void set_bit(size_t pos, bool value){
+#ifndef BITVECTOR_DISABLE_BOUNDS_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
+#endif
             BitType mask = 1UL << (pos % WORD_BITS);
             BitType * ptr = &m_data[pos / WORD_BITS];
             if (value)
@@ -316,12 +322,14 @@ namespace bowen
         }
         void incrementUntilZero(size_t& pos){
             // Ensure the position is within bounds
+#ifndef BITVECTOR_DISABLE_BOUNDS_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
                     return;
             }
+#endif
             while (pos < m_size&& pos%WORD_BITS!=0 && (*this)[pos] != 0) // Check if bit at pos is 1
             {
                 ++pos; // Increment pos to the next bit


### PR DESCRIPTION
## Summary
- make bounds checking optional via BV_BOUNDS_CHECK
- guard runtime checks with `BITVECTOR_DISABLE_BOUNDS_CHECK`
- document running benchmarks without bounds checks

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684399d742348327a2036d791d966843