### PR TITLE
Separate unit/performance CI, optional bounds check

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,4 +1,4 @@
-name: C++ CI
+name: Performance Benchmarks
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  benchmark:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,8 +16,6 @@ jobs:
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
       - name: Build
         run: cmake --build build --config Release
-      - name: Run tests
-        run: ctest --test-dir build --output-on-failure
       - name: Run benchmarks
         run: ./build/bitvector_benchmark --benchmark_min_time=0.01s
       - name: Dump benchmark assembly

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,20 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ elseif(MSVC)
 endif()
 
 # Optionally disable bounds checking in the bitvector implementation
-option(BITVECTOR_ENABLE_BOUND_CHECK "Enable bounds checking in bitvector" ON)
+option(BITVECTOR_ENABLE_BOUND_CHECK "Enable bounds checking in bitvector" OFF)
 if(NOT BITVECTOR_ENABLE_BOUND_CHECK)
     add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ elseif(MSVC)
     message(WARNING "BMI1 support is not available for MSVC in this configuration.")
 endif()
 
+# Optionally disable bounds checking in the bitvector implementation
+option(BITVECTOR_ENABLE_BOUND_CHECK "Enable bounds checking in bitvector" ON)
+if(NOT BITVECTOR_ENABLE_BOUND_CHECK)
+    add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
+endif()
+
 # Enable testing
 enable_testing()
 

--- a/bitvector.hpp
+++ b/bitvector.hpp
@@ -208,11 +208,13 @@ namespace bowen
 
         reference operator[](size_t pos)
         {
+#ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
+#endif
 
             size_t word_index = pos >> WORD_SHIFT;
             BitType mask = static_cast<BitType>(1) << (pos & (WORD_BITS - 1));
@@ -221,21 +223,25 @@ namespace bowen
 
         bool operator[](size_t pos) const
         {
+#ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
+#endif
             size_t word_index = pos >> WORD_SHIFT;
             BitType mask = static_cast<BitType>(1) << (pos & (WORD_BITS - 1));
             return (m_data[word_index] & mask) != 0;
         }
         inline void set_bit(size_t pos, bool value){
+#ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
+#endif
             BitType mask = 1UL << (pos % WORD_BITS);
             BitType * ptr = &m_data[pos / WORD_BITS];
             if (value)
@@ -316,12 +322,14 @@ namespace bowen
         }
         void incrementUntilZero(size_t& pos){
             // Ensure the position is within bounds
+#ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
                 ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
                     return;
             }
+#endif
             while (pos < m_size&& pos%WORD_BITS!=0 && (*this)[pos] != 0) // Check if bit at pos is 1
             {
                 ++pos; // Increment pos to the next bit

--- a/bitvector_test.cpp
+++ b/bitvector_test.cpp
@@ -37,11 +37,13 @@ TEST(BitvectorTest, ConstructWithValue) {
     }
 }
 
+#ifndef BITVECTOR_NO_BOUND_CHECK
 TEST(BitvectorTest, OutOfRangeThrows) {
     bowen::bitvector<> bv(5);
     EXPECT_THROW(bv[5], std::out_of_range);
     EXPECT_THROW(bv.set_bit(5, true), std::out_of_range);
 }
+#endif
 
 TEST(BitvectorTest, CopyAndAssignment) {
     bowen::bitvector<> bv1;


### PR DESCRIPTION
## Summary
- split GitHub Actions into unit tests and performance benchmarks
- add CMake option `BITVECTOR_ENABLE_BOUND_CHECK` to allow disabling bounds checks
- guard all bounds checks in `bitvector.hpp` with `BITVECTOR_NO_BOUND_CHECK`
- skip out-of-range test when bounds checking is disabled

## Testing
- `cmake -DBITVECTOR_ENABLE_BOUND_CHECK=ON ..`
- `cmake --build .`
- `ctest --output-on-failure`
- `cmake -DBITVECTOR_ENABLE_BOUND_CHECK=OFF ..`
- `cmake --build .`
- `ctest --output-on-failure`
- `./bitvector_benchmark --benchmark_min_time=0.01s`

------
https://chatgpt.com/codex/tasks/task_e_68439db78c88832785e40edbe06478ba