### PR TITLE
Ensure 5s per benchmark run

### DIFF
--- a/bitvector_benchmark.cpp
+++ b/bitvector_benchmark.cpp
@@ -72,11 +72,11 @@ static void BM_Std_Access(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Bowen_Set)->Arg(1<<20);
-BENCHMARK(BM_Std_Set)->Arg(1<<20);
-BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20);
-BENCHMARK(BM_Std_PushBack)->Arg(1<<20);
-BENCHMARK(BM_Bowen_Access)->Arg(1<<20);
-BENCHMARK(BM_Std_Access)->Arg(1<<20);
+BENCHMARK(BM_Bowen_Set)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_Set)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_PushBack)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_Access)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_Access)->Arg(1<<20)->MinTime(5.0);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
## Summary
- enforce a minimum runtime of five seconds for each benchmark by using `MinTime(5.0)`
- rebuild and execute benchmarks to confirm min_time setting

## Testing
- `cmake -S . -B build -DBV_BOUNDS_CHECK=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `./build/bitvector_benchmark`

------
https://chatgpt.com/codex/tasks/task_e_6843a35638c08327b5d1dedb50c538fd