### PR TITLE
Consolidate bounds check macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.21)
 project(bitvector)
 
 set(CMAKE_CXX_STANDARD 17)
-option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" OFF)
-if(NOT BV_BOUNDS_CHECK)
-  add_compile_definitions(BITVECTOR_DISABLE_BOUNDS_CHECK)
+option(BITVECTOR_NO_BOUND_CHECK "Disable bounds checking in bitvector" OFF)
+if(BITVECTOR_NO_BOUND_CHECK)
+  add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
 endif()
 if(MSVC)
   # Set compiler flags for all configurations
@@ -35,10 +35,6 @@ elseif(MSVC)
 endif()
 
 # Optionally disable bounds checking in the bitvector implementation
-option(BITVECTOR_ENABLE_BOUND_CHECK "Enable bounds checking in bitvector" OFF)
-if(NOT BITVECTOR_ENABLE_BOUND_CHECK)
-    add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
-endif()
 
 # Enable testing
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository provides a small bit vector implementation along with tests and 
 Bounds checking is enabled by default. To benchmark without checks, configure and build with:
 
 ```bash
-cmake -S . -B build -DBV_BOUNDS_CHECK=OFF -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build -DBITVECTOR_NO_BOUND_CHECK=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release
 ./build/bitvector_benchmark
 ```


### PR DESCRIPTION
## Summary
- use only `BITVECTOR_NO_BOUND_CHECK` in CMake
- update README instructions for disabling bounds checks
- drop leftover macro option

## Testing
- `cmake -S . -B build -DBITVECTOR_NO_BOUND_CHECK=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_6843a366253c83278c2f1021254a3411