### PR TITLE
Fix SIZE comment

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,7 @@
 #include <chrono>
 #include <iostream>
 #include <vector>
-constexpr size_t SIZE = 1000000000;  // 10 million elements
+constexpr size_t SIZE = 1000000000;  // 1 billion elements
 // Benchmarks the performance of std::vector<bool> for setting, accessing, and traversing elements.
 void benchmarkStdVectorBool(){
 


### PR DESCRIPTION
## Summary
- correct SIZE comment in `main.cpp`

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6843a36dd30c8327b7b1a024818301ed