### PR TITLE
Add microbenchmarks and clean bounds check config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.21)
 project(bitvector)
 
 set(CMAKE_CXX_STANDARD 17)
-option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" ON)
-if(NOT BV_BOUNDS_CHECK)
+option(BITVECTOR_NO_BOUND_CHECK "Disable bounds checking in bitvector" OFF)
+if(BITVECTOR_NO_BOUND_CHECK)
   add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
 endif()
 if(MSVC)
@@ -34,6 +34,7 @@ elseif(MSVC)
     message(WARNING "BMI1 support is not available for MSVC in this configuration.")
 endif()
 
+# Optionally disable bounds checking in the bitvector implementation
 
 # Enable testing
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.21)
 project(bitvector)
 
 set(CMAKE_CXX_STANDARD 17)
-option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" OFF)
+option(BV_BOUNDS_CHECK "Enable bounds checking in bitvector" ON)
 if(NOT BV_BOUNDS_CHECK)
-  add_compile_definitions(BITVECTOR_DISABLE_BOUNDS_CHECK)
+  add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
 endif()
 if(MSVC)
   # Set compiler flags for all configurations
@@ -34,11 +34,6 @@ elseif(MSVC)
     message(WARNING "BMI1 support is not available for MSVC in this configuration.")
 endif()
 
-# Optionally disable bounds checking in the bitvector implementation
-option(BITVECTOR_ENABLE_BOUND_CHECK "Enable bounds checking in bitvector" OFF)
-if(NOT BITVECTOR_ENABLE_BOUND_CHECK)
-    add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
-endif()
 
 # Enable testing
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository provides a small bit vector implementation along with tests and 
 Bounds checking is enabled by default. To benchmark without checks, configure and build with (this defines `BITVECTOR_NO_BOUND_CHECK`):
 
 ```bash
-cmake -S . -B build -DBV_BOUNDS_CHECK=OFF -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build -DBITVECTOR_NO_BOUND_CHECK=ON -DCMAKE_BUILD_TYPE=Release
 cmake --build build --config Release
 ./build/bitvector_benchmark
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository provides a small bit vector implementation along with tests and 
 
 ## Running the benchmarks without bounds checking
 
-Bounds checking is enabled by default. To benchmark without checks, configure and build with:
+Bounds checking is enabled by default. To benchmark without checks, configure and build with (this defines `BITVECTOR_NO_BOUND_CHECK`):
 
 ```bash
 cmake -S . -B build -DBV_BOUNDS_CHECK=OFF -DCMAKE_BUILD_TYPE=Release

--- a/bitvector_benchmark.cpp
+++ b/bitvector_benchmark.cpp
@@ -72,11 +72,87 @@ static void BM_Std_Access(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Bowen_Set)->Arg(1<<20);
-BENCHMARK(BM_Std_Set)->Arg(1<<20);
-BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20);
-BENCHMARK(BM_Std_PushBack)->Arg(1<<20);
-BENCHMARK(BM_Bowen_Access)->Arg(1<<20);
-BENCHMARK(BM_Std_Access)->Arg(1<<20);
+static void BM_Bowen_SetBitTrue6(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    bitvector<> bv(n);
+    for (size_t pos=0; pos+5 < n; pos+=6) {
+      bv.set_bit_true_6(pos, 1);
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Std_SetBitTrue6(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    std::vector<bool> bv(n);
+    for (size_t pos=0; pos+5 < n; pos+=6) {
+      for (int i=0;i<6;++i) {
+        bv[pos+i] = true;
+      }
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Bowen_QSetBitTrue6V2(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    bitvector<> bv(n);
+    bv.qset_bit_true_6_v2(0, 1, n);
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Std_QSetBitTrue6(benchmark::State& state) {
+  size_t n = state.range(0);
+  for (auto _ : state) {
+    std::vector<bool> bv(n);
+    for (size_t i=0;i<n;++i) {
+      bv[i] = true;
+    }
+    benchmark::ClobberMemory();
+  }
+}
+
+static void BM_Bowen_IncrementUntilZero(benchmark::State& state) {
+  size_t n = state.range(0);
+  bitvector<> bv(n, true);
+  bv.set_bit(n-1, false);
+  for (auto _ : state) {
+    size_t pos = 0;
+    bv.incrementUntilZero(pos);
+    benchmark::DoNotOptimize(pos);
+  }
+}
+
+static void incrementUntilZeroStd(const std::vector<bool>& bv, size_t& pos) {
+  while (pos < bv.size() && bv[pos]) ++pos;
+}
+
+static void BM_Std_IncrementUntilZero(benchmark::State& state) {
+  size_t n = state.range(0);
+  std::vector<bool> bv(n, true);
+  bv[n-1] = false;
+  for (auto _ : state) {
+    size_t pos = 0;
+    incrementUntilZeroStd(bv, pos);
+    benchmark::DoNotOptimize(pos);
+  }
+}
+
+BENCHMARK(BM_Bowen_Set)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_Set)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_PushBack)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_Access)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_Access)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_SetBitTrue6)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_SetBitTrue6)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_QSetBitTrue6V2)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_QSetBitTrue6)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_IncrementUntilZero)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Std_IncrementUntilZero)->Arg(1<<20)->MinTime(5.0);
 
 BENCHMARK_MAIN();

--- a/main.cpp
+++ b/main.cpp
@@ -3,7 +3,8 @@
 #include <chrono>
 #include <iostream>
 #include <vector>
-constexpr size_t SIZE = 1000000000;  // 10 million elements
+// Benchmark size: 1 billion elements
+constexpr size_t SIZE = 1000000000;
 // Benchmarks the performance of std::vector<bool> for setting, accessing, and traversing elements.
 void benchmarkStdVectorBool(){
 


### PR DESCRIPTION
## Summary
- clarify comment for benchmark SIZE constant
- extend Google Benchmark registrations to run at least 5 seconds
- benchmark specialised bitvector routines (`set_bit_true_6`, `qset_bit_true_6_v2`, `incrementUntilZero`) and std::vector equivalents
- consolidate bounds‑check option to `BITVECTOR_NO_BOUND_CHECK`

## Testing
- `cmake -S . -B build -DBV_BOUNDS_CHECK=OFF -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target bitvector_benchmark bitvector_tests`
- `./build/bitvector_tests`
- `./build/bitvector_benchmark --benchmark_min_time=0.01`

------
https://chatgpt.com/codex/tasks/task_e_6843a19f5fc483278d9181d05be2d477