### PR TITLE
Make test and benchmark durations configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.21)
 project(bitvector)
 
 set(CMAKE_CXX_STANDARD 17)
+
+# Allow configuring how long tests may run and how long benchmarks
+# should execute.  The timeout for GoogleTest-based unit tests is set via
+# `BITVECTOR_TEST_TIMEOUT`.  The minimum runtime for Google Benchmark
+# benchmarks is configured with `BITVECTOR_BENCHMARK_MIN_TIME`.
+set(BITVECTOR_TEST_TIMEOUT 10 CACHE STRING "Timeout in seconds for each unit test")
+set(BITVECTOR_BENCHMARK_MIN_TIME 0.2 CACHE STRING "Minimum time in seconds for benchmark runs")
 option(BITVECTOR_NO_BOUND_CHECK "Disable bounds checking in bitvector" OFF)
 if(BITVECTOR_NO_BOUND_CHECK)
   add_compile_definitions(BITVECTOR_NO_BOUND_CHECK)
@@ -78,6 +85,7 @@ target_link_libraries(bitvector_tests GTest::gtest_main)
 # Benchmark target
 add_executable(bitvector_benchmark bitvector_benchmark.cpp)
 target_link_libraries(bitvector_benchmark benchmark::benchmark)
+target_compile_definitions(bitvector_benchmark PRIVATE BITVECTOR_BENCHMARK_MIN_TIME=${BITVECTOR_BENCHMARK_MIN_TIME})
 
 
 # Link your project with Google Test (only for test purposes)
@@ -91,5 +99,5 @@ target_link_libraries(bitvector_benchmark benchmark::benchmark)
 
 # Enable test discovery
 include(GoogleTest)
-gtest_discover_tests(bitvector_tests)
+gtest_discover_tests(bitvector_tests PROPERTIES TIMEOUT ${BITVECTOR_TEST_TIMEOUT})
 

--- a/bitvector_benchmark.cpp
+++ b/bitvector_benchmark.cpp
@@ -2,6 +2,10 @@
 #include <benchmark/benchmark.h>
 #include <vector>
 
+#ifndef BITVECTOR_BENCHMARK_MIN_TIME
+#define BITVECTOR_BENCHMARK_MIN_TIME 0.2
+#endif
+
 using bowen::bitvector;
 
 static void BM_Bowen_Set(benchmark::State& state) {
@@ -143,17 +147,17 @@ static void BM_Std_IncrementUntilZero(benchmark::State& state) {
   }
 }
 
-BENCHMARK(BM_Bowen_Set)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Std_Set)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Std_PushBack)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Bowen_Access)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Std_Access)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Bowen_SetBitTrue6)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Std_SetBitTrue6)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Bowen_QSetBitTrue6V2)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Std_QSetBitTrue6)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Bowen_IncrementUntilZero)->Arg(1<<20)->MinTime(5.0);
-BENCHMARK(BM_Std_IncrementUntilZero)->Arg(1<<20)->MinTime(5.0);
+BENCHMARK(BM_Bowen_Set)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Std_Set)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Bowen_PushBack)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Std_PushBack)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Bowen_Access)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Std_Access)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Bowen_SetBitTrue6)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Std_SetBitTrue6)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Bowen_QSetBitTrue6V2)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Std_QSetBitTrue6)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Bowen_IncrementUntilZero)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
+BENCHMARK(BM_Std_IncrementUntilZero)->Arg(1<<20)->MinTime(BITVECTOR_BENCHMARK_MIN_TIME);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
## Summary
- add `BITVECTOR_TEST_TIMEOUT` and `BITVECTOR_BENCHMARK_MIN_TIME` CMake options
- compile benchmark with configurable minimum runtime
- update benchmark code to use new definition

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6843abb515608327aba150d6de533900