### PR TITLE
Fix reserve units for bitvector

### DIFF
--- a/bitvector.hpp
+++ b/bitvector.hpp
@@ -356,16 +356,16 @@ namespace bowen
         {
             if (m_size == m_capacity * WORD_BITS)
             {
-                reserve(m_capacity == 0 ? 1 : m_capacity * 2);
+                reserve(m_capacity ? m_capacity * WORD_BITS * 2 : WORD_BITS);
             }
             (*this)[m_size++] = value;
         }
 
         void reserve(size_t new_capacity)
         {
-            if (new_capacity > m_capacity)
+            if (new_capacity > m_capacity * WORD_BITS)
             {
-                size_t new_word_count = num_words(new_capacity * WORD_BITS);
+                size_t new_word_count = num_words(new_capacity);
                 
                 BitType *new_data = m_allocator.allocate(new_word_count);
                 std::copy(m_data, m_data + m_capacity, new_data);


### PR DESCRIPTION
## Summary
- fix `reserve()` to accept capacity in bits
- adjust `push_back()` growth logic to use bit capacity
- rebuild and run benchmarks to ensure performance

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `ctest --test-dir build -j $(nproc) --output-on-failure`
- `./build/bitvector_benchmark --benchmark_filter=BM_Bowen_PushBack --benchmark_min_time=0.2`

------
https://chatgpt.com/codex/tasks/task_e_6843af4c69cc8327b077408b47c5ed06