### PR TITLE
Enable optional AVX2/march support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,26 @@ elseif(MSVC)
     message(WARNING "BMI1 support is not available for MSVC in this configuration.")
 endif()
 
+# Detect AVX2 or native CPU optimizations and enable them if available
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+    if(COMPILER_SUPPORTS_MARCH_NATIVE)
+        add_compile_options(-march=native)
+    else()
+        check_cxx_compiler_flag("-mavx2" COMPILER_SUPPORTS_AVX2)
+        if(COMPILER_SUPPORTS_AVX2)
+            add_compile_options(-mavx2)
+        endif()
+    endif()
+elseif(MSVC)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("/arch:AVX2" COMPILER_SUPPORTS_AVX2)
+    if(COMPILER_SUPPORTS_AVX2)
+        add_compile_options(/arch:AVX2)
+    endif()
+endif()
+
 # Optionally disable bounds checking in the bitvector implementation
 
 # Enable testing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This repository provides a small bit vector implementation along with tests and 
 
 ## Running the benchmarks without bounds checking
 
-Bounds checking is enabled by default. To benchmark without checks, configure and build with (this defines `BITVECTOR_NO_BOUND_CHECK`):
+Bounds checking is enabled by default. To benchmark without checks, configure
+and build with (this defines `BITVECTOR_NO_BOUND_CHECK`). The build system now
+detects whether the compiler and host CPU support AVX2 or other native
+instructions and enables them when possible:
 
 ```bash
 cmake -S . -B build -DBITVECTOR_NO_BOUND_CHECK=ON -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Summary
- enable automatic AVX2 or native CPU flags in CMake
- mention this new detection in the README

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j $(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6843ae71bec88327bf519470e4c4e25d