### PR TITLE
Rename bitvector class to BitVector

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following table shows benchmark times from the latest CI run. Each test was 
 `incrementUntilZero` scans the bit vector starting at the given position until it reaches the first zero bit. The position is updated in place:
 
 ```cpp
-bitvector<> bv(1024, true);
+BitVector<> bv(1024, true);
 bv.set_bit(1023, false); // ensure there is a zero bit
 size_t pos = 0;
 bv.incrementUntilZero(pos);

--- a/bitvector.hpp
+++ b/bitvector.hpp
@@ -141,7 +141,7 @@ namespace bowen
         }
     };
     template<typename Allocator = std::allocator<BitType>>
-    class bitvector
+    class BitVector
     {
     private:
         BitType* m_data;
@@ -170,24 +170,24 @@ namespace bowen
         typedef size_t size_type;
         typedef BitReference<Allocator> reference;
 
-        bitvector()
+        BitVector()
             : m_data(nullptr), m_size(0), m_capacity(0) {}
 
-        explicit bitvector(size_t n, bool value = false)
+        explicit BitVector(size_t n, bool value = false)
             : m_size(n), m_capacity(num_words(n))
         {
             allocate_memory(m_capacity);
             std::memset(m_data, value ? ~0 : 0, m_capacity * sizeof(BitType));
         }
 
-        bitvector(const bitvector& other)
+        BitVector(const BitVector& other)
             : m_size(other.m_size), m_capacity(other.m_capacity)
         {
             allocate_memory(m_capacity);
             std::copy(other.m_data, other.m_data + m_capacity, m_data);
         }
 
-        bitvector& operator=(const bitvector& other)
+        BitVector& operator=(const BitVector& other)
         {
             if (this != &other)
             {
@@ -201,7 +201,7 @@ namespace bowen
             return *this;
         }
 
-        ~bitvector()
+        ~BitVector()
         {
             deallocate_memory();
         }
@@ -211,7 +211,7 @@ namespace bowen
 #ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
-                ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
+                ss << "BitVector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
 #endif
@@ -226,7 +226,7 @@ namespace bowen
 #ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
-                ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
+                ss << "BitVector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
 #endif
@@ -238,7 +238,7 @@ namespace bowen
 #ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
-                ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
+                ss << "BitVector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
             }
 #endif
@@ -325,7 +325,7 @@ namespace bowen
 #ifndef BITVECTOR_NO_BOUND_CHECK
             if (pos >= m_size){
                 std::stringstream  ss;
-                ss << "bitvector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
+                ss << "BitVector index out of range" << "pos: "<< pos << " size: " << m_size << std::endl;
                 throw std::out_of_range(ss.str());
                     return;
             }

--- a/bitvector_benchmark.cpp
+++ b/bitvector_benchmark.cpp
@@ -6,12 +6,12 @@
 #define BITVECTOR_BENCHMARK_MIN_TIME 0.2
 #endif
 
-using bowen::bitvector;
+using bowen::BitVector;
 
 static void BM_Bowen_Set(benchmark::State& state) {
   size_t n = state.range(0);
   for (auto _ : state) {
-    bitvector<> bv(n);
+    BitVector<> bv(n);
     for (size_t i=0;i<n;++i) {
       bv[i] = static_cast<bool>(i & 1);
     }
@@ -33,7 +33,7 @@ static void BM_Std_Set(benchmark::State& state) {
 static void BM_Bowen_PushBack(benchmark::State& state) {
   size_t n = state.range(0);
   for (auto _ : state) {
-    bitvector<> bv;
+    BitVector<> bv;
     bv.reserve(n);
     for (size_t i=0;i<n;++i) {
       bv.push_back(static_cast<bool>(i & 1));
@@ -56,7 +56,7 @@ static void BM_Std_PushBack(benchmark::State& state) {
 
 static void BM_Bowen_Access(benchmark::State& state) {
   size_t n = state.range(0);
-  bitvector<> bv(n);
+  BitVector<> bv(n);
   for (size_t i=0;i<n;++i) bv[i] = static_cast<bool>(i & 1);
   for (auto _ : state) {
     size_t sum=0;
@@ -79,7 +79,7 @@ static void BM_Std_Access(benchmark::State& state) {
 static void BM_Bowen_SetBit(benchmark::State& state) {
   size_t n = state.range(0);
   for (auto _ : state) {
-    bitvector<> bv(n);
+    BitVector<> bv(n);
     for (size_t i=0;i<n;++i) {
       bv.set_bit(i, static_cast<bool>(i & 1));
     }
@@ -101,7 +101,7 @@ static void BM_Std_SetBit(benchmark::State& state) {
 static void BM_Bowen_SetBitTrueUnsafe(benchmark::State& state) {
   size_t n = state.range(0);
   for (auto _ : state) {
-    bitvector<> bv(n);
+    BitVector<> bv(n);
     for (size_t i=0;i<n;++i) {
       bv.set_bit_true_unsafe(i);
     }
@@ -124,7 +124,7 @@ static void BM_Std_SetBitTrueUnsafe(benchmark::State& state) {
 static void BM_Bowen_SetBitTrue6(benchmark::State& state) {
   size_t n = state.range(0);
   for (auto _ : state) {
-    bitvector<> bv(n);
+    BitVector<> bv(n);
     for (size_t pos=0; pos+5 < n; pos+=6) {
       bv.set_bit_true_6(pos, 1);
     }
@@ -148,7 +148,7 @@ static void BM_Std_SetBitTrue6(benchmark::State& state) {
 static void BM_Bowen_QSetBitTrue6V2(benchmark::State& state) {
   size_t n = state.range(0);
   for (auto _ : state) {
-    bitvector<> bv(n);
+    BitVector<> bv(n);
     bv.qset_bit_true_6_v2(0, 1, n);
     benchmark::ClobberMemory();
   }
@@ -167,7 +167,7 @@ static void BM_Std_QSetBitTrue6(benchmark::State& state) {
 
 static void BM_Bowen_IncrementUntilZero(benchmark::State& state) {
   size_t n = state.range(0);
-  bitvector<> bv(n, true);
+  BitVector<> bv(n, true);
   bv.set_bit(n-1, false);
   for (auto _ : state) {
     size_t pos = 0;

--- a/bitvector_test.cpp
+++ b/bitvector_test.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 
 TEST(BitvectorTest, PushBackBasic) {
-    bowen::bitvector<> bv;
+    bowen::BitVector<> bv;
     EXPECT_TRUE(bv.empty());
 
     bv.push_back(false);
@@ -17,7 +17,7 @@ TEST(BitvectorTest, PushBackBasic) {
 
 TEST(BitvectorTest, IncrementUntilZero) {
     const size_t N = 20;
-    bowen::bitvector<> bv(N);
+    bowen::BitVector<> bv(N);
 
     // Set bits 5 through 7 to 1
     for (size_t i = 5; i <= 7; ++i) {
@@ -30,7 +30,7 @@ TEST(BitvectorTest, IncrementUntilZero) {
 }
 
 TEST(BitvectorTest, ConstructWithValue) {
-    bowen::bitvector<> bv(10, true);
+    bowen::BitVector<> bv(10, true);
     ASSERT_EQ(bv.size(), 10u);
     for (size_t i = 0; i < bv.size(); ++i) {
         EXPECT_TRUE(bv[i]);
@@ -39,18 +39,18 @@ TEST(BitvectorTest, ConstructWithValue) {
 
 #ifndef BITVECTOR_NO_BOUND_CHECK
 TEST(BitvectorTest, OutOfRangeThrows) {
-    bowen::bitvector<> bv(5);
+    bowen::BitVector<> bv(5);
     EXPECT_THROW(bv[5], std::out_of_range);
     EXPECT_THROW(bv.set_bit(5, true), std::out_of_range);
 }
 #endif
 
 TEST(BitvectorTest, CopyAndAssignment) {
-    bowen::bitvector<> bv1;
+    bowen::BitVector<> bv1;
     bv1.push_back(false);
     bv1.push_back(true);
 
-    bowen::bitvector<> bv2(bv1);
+    bowen::BitVector<> bv2(bv1);
     ASSERT_EQ(bv2.size(), bv1.size());
     EXPECT_FALSE(bv2[0]);
     EXPECT_TRUE(bv2[1]);
@@ -59,7 +59,7 @@ TEST(BitvectorTest, CopyAndAssignment) {
     EXPECT_TRUE(bv1[0]);
     EXPECT_FALSE(bv2[0]);
 
-    bowen::bitvector<> bv3;
+    bowen::BitVector<> bv3;
     bv3 = bv1;
     ASSERT_EQ(bv3.size(), bv1.size());
     EXPECT_TRUE(bv3[0]);
@@ -67,7 +67,7 @@ TEST(BitvectorTest, CopyAndAssignment) {
 }
 
 TEST(BitvectorTest, AssignResizesAndSets) {
-    bowen::bitvector<> bv;
+    bowen::BitVector<> bv;
     bv.assign(12, true);
     ASSERT_EQ(bv.size(), 12u);
     for (size_t i = 0; i < bv.size(); ++i)
@@ -80,7 +80,7 @@ TEST(BitvectorTest, AssignResizesAndSets) {
 }
 
 TEST(BitvectorTest, IteratorTraversal) {
-    bowen::bitvector<> bv;
+    bowen::BitVector<> bv;
     bv.push_back(true);
     bv.push_back(false);
     bv.push_back(true);

--- a/main.cpp
+++ b/main.cpp
@@ -50,13 +50,13 @@ void benchmarkStdVectorBool(){
     std::cout << "[std::vector<bool>] True count: " << true_count << std::endl;
 }
 
-// Benchmarks the performance of bowen::bitvector for setting, assigning, accessing, and traversing elements.
+// Benchmarks the performance of bowen::BitVector for setting, assigning, accessing, and traversing elements.
 void benchmarkBowenBitvector(){
 
-    std::cout << "Benchmarking bowen::bitvector..." << std::endl;
+    std::cout << "Benchmarking bowen::BitVector..." << std::endl;
 
     // Define a bitvector
-    bowen::bitvector bool_vector(SIZE);
+    bowen::BitVector bool_vector(SIZE);
 
     // Time setting each element
     auto start_set = std::chrono::high_resolution_clock::now();
@@ -65,15 +65,15 @@ void benchmarkBowenBitvector(){
     }
     auto end_set = std::chrono::high_resolution_clock::now();
     auto duration_set = std::chrono::duration_cast<std::chrono::milliseconds>(end_set - start_set);
-    std::cout << "[bowen::bitvector] Setting all elements took " << duration_set.count() << " milliseconds." << std::endl;
+    std::cout << "[bowen::BitVector] Setting all elements took " << duration_set.count() << " milliseconds." << std::endl;
 
     // Time setting each element using assign
     auto start_assign = std::chrono::high_resolution_clock::now();
-    bowen::bitvector vector2;
+    bowen::BitVector vector2;
     vector2.assign(SIZE, 1);
     auto end_assign = std::chrono::high_resolution_clock::now();
     auto duration_assign = std::chrono::duration_cast<std::chrono::milliseconds>(end_assign - start_assign);
-    std::cout << "[bowen::bitvector] Assigning all elements took " << duration_assign.count() << " milliseconds." << std::endl;
+    std::cout << "[bowen::BitVector] Assigning all elements took " << duration_assign.count() << " milliseconds." << std::endl;
 
     // Time accessing each element
     size_t true_count = 0;
@@ -85,7 +85,7 @@ void benchmarkBowenBitvector(){
     }
     auto end_access = std::chrono::high_resolution_clock::now();
     auto duration_access = std::chrono::duration_cast<std::chrono::milliseconds>(end_access - start_access);
-    std::cout << "[bowen::bitvector] Accessing all elements took " << duration_access.count() << " milliseconds." << std::endl;
+    std::cout << "[bowen::BitVector] Accessing all elements took " << duration_access.count() << " milliseconds." << std::endl;
 
     // Time traversing the entire vector
     auto start_traverse = std::chrono::high_resolution_clock::now();
@@ -96,16 +96,16 @@ void benchmarkBowenBitvector(){
     }
     auto end_traverse = std::chrono::high_resolution_clock::now();
     auto duration_traverse = std::chrono::duration_cast<std::chrono::milliseconds>(end_traverse - start_traverse);
-    std::cout << "[bowen::bitvector] Traversing all elements took " << duration_traverse.count() << " milliseconds." << std::endl;
+    std::cout << "[bowen::BitVector] Traversing all elements took " << duration_traverse.count() << " milliseconds." << std::endl;
 
-    std::cout << "[bowen::bitvector] True count: " << true_count << std::endl;
+    std::cout << "[bowen::BitVector] True count: " << true_count << std::endl;
 }
 
-// Compares the behavior of bowen::bitvector against std::vector<bool> for basic operations.
+// Compares the behavior of bowen::BitVector against std::vector<bool> for basic operations.
 void testBitvectorAgainstStdVectorBool(){
 
     // Define a bitvector and a vector<bool>
-    bowen::bitvector bool_vector1(SIZE);
+    bowen::BitVector bool_vector1(SIZE);
     std::vector<bool> bool_vector2(SIZE);
     // Time setting each element
     auto start_set = std::chrono::high_resolution_clock::now();
@@ -134,14 +134,14 @@ void testBitvectorAgainstStdVectorBool(){
 
 }
 
-// Tests the incrementUntilZero method of bowen::bitvector.
+// Tests the incrementUntilZero method of bowen::BitVector.
 // This method is expected to increment a counter starting from a given position
 // as long as it encounters '1's in the bitvector, stopping at the first '0' or the end of the vector.
 void testBitvectorIncrementUntilZero(){
     constexpr size_t SIZE = 128*10;  // Size of the bitvector
 
     // Define a bitvector
-    bowen::bitvector bool_vector1(SIZE);
+    bowen::BitVector bool_vector1(SIZE);
     // Time setting some elements to true
     int start = rand()%(SIZE-2);
     int correct_count=start;
@@ -165,7 +165,7 @@ void testBitvectorIncrementUntilZero(){
 
 void calculateSpeedup(double std_time, double bowen_time) {
     double speedup = std_time / bowen_time;
-    std::cout << "Speedup (std::vector<bool> vs bowen::bitvector): " << speedup << "x" << std::endl;
+    std::cout << "Speedup (std::vector<bool> vs bowen::BitVector): " << speedup << "x" << std::endl;
 }
 
 int main() {
@@ -175,7 +175,7 @@ int main() {
     auto end_std = std::chrono::high_resolution_clock::now();
     double std_time = std::chrono::duration_cast<std::chrono::milliseconds>(end_std - start_std).count();
 
-    // Benchmark bowen::bitvector
+    // Benchmark bowen::BitVector
     auto start_bowen = std::chrono::high_resolution_clock::now();
     benchmarkBowenBitvector();
     auto end_bowen = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
## Summary
- rename the `bitvector` class to `BitVector`
- update usages in benchmarks, tests and examples

## Testing
- `cmake -S . -B build -DBITVECTOR_NO_BOUND_CHECK=ON -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release`
- `ctest --test-dir build --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6843e0f8330083278f99ccab62c7a433